### PR TITLE
Add information about rewind in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ RGeo::Shapefile::Reader.open('myshpfil.shp') do |file|
     puts "  Geometry: #{record.geometry.as_text}"
     puts "  Attributes: #{record.attributes.inspect}"
   end
+  # If using version 3.0.0 or earlier, rewind is necessary to return to the beginning of the file.
+  # file.rewind
   record = file.next
   puts "First record geometry was: #{record.geometry.as_text}"
 end


### PR DESCRIPTION
### Motivation
I'm currently using version 2.0 of rgeo-shapefile and had problems running the example, this because it only works in the current version. I believe that it is useful to inform people what is necessary to do so that the example works in the old versions.

### Activities
Added the following code in the readme:
```ruby
  # If using version 3.0.0 or earlier, rewind is necessary to return to the beginning of the file.
  # file.rewind
```